### PR TITLE
Update Number test

### DIFF
--- a/src/types/TypeNumber.ts
+++ b/src/types/TypeNumber.ts
@@ -107,10 +107,7 @@ export class TypeNumber extends TypeAny {
   }
 
   // Function when test and transform param
-  _isTypeNum = () => typeof this._value === 'number';
-  _isInteger = () => !!`${this._value}`.match(/^-{0,1}\d+$/);
-  _isFloat = () => !!`${this._value}`.match(/^-?\d+\.\d+$/);
-  _isNumber = () => this._isInteger() || this._isFloat();
+  _isNumber = () => !Number.isNaN(+`${this._value`);
 
   _testType() {
     if (!this._isNumber()) {


### PR DESCRIPTION
When a very small number like 5e-6 is passed to TypeNumber, it is rejected as "not a valid number" but is just very small with a different notation.